### PR TITLE
Migrate the SDK to AndroidX and update dependencies

### DIFF
--- a/sources/Android/android-communications/build.gradle
+++ b/sources/Android/android-communications/build.gradle
@@ -45,7 +45,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         if ( project.hasProperty("artifactoryUser") && project.hasProperty("artifactoryPassword") ) {
             classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.7.3"
         }
@@ -53,12 +53,11 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 13
         versionName "13"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -162,19 +161,26 @@ artifacts {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     if (project.hasProperty("buildSdk")) {
-        implementation files('libs/polar-protobuf-release.aar')
+        compileOnly files('libs/polar-protobuf-release.aar')
         implementation 'com.google.protobuf:protobuf-java:3.1.0'
     } else {
         implementation project(':polar-protobuf')
         implementation 'com.google.protobuf:protobuf-java:3.1.0'
     }
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation "org.mockito:mockito-core:3.2.4"
     testImplementation "io.mockk:mockk:1.9.3"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
     implementation 'io.reactivex.rxjava3:rxjava:3.0.0'
-    implementation 'commons-io:commons-io:2.4'
-    implementation 'com.android.support:support-annotations:28.0.0'
+    //noinspection GradleDependency: recommends an ancient version
+    implementation 'commons-io:commons-io:2.8.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
+}
+
+allprojects {
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+    }
 }

--- a/sources/Android/android-communications/build.gradle
+++ b/sources/Android/android-communications/build.gradle
@@ -171,6 +171,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:3.2.4"
     testImplementation "io.mockk:mockk:1.9.3"
     androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
     implementation 'io.reactivex.rxjava3:rxjava:3.0.0'

--- a/sources/Android/android-communications/build.gradle
+++ b/sources/Android/android-communications/build.gradle
@@ -47,7 +47,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
         if ( project.hasProperty("artifactoryUser") && project.hasProperty("artifactoryPassword") ) {
-            classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.7.3"
+            classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.18.1"
         }
     }
 }
@@ -160,7 +160,7 @@ artifacts {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    if (project.hasProperty("buildSdk")) {
+    if (project.hasProperty("buildSdk") || !file("polar-protobuf").isDirectory()) {
         compileOnly files('libs/polar-protobuf-release.aar')
         implementation 'com.google.protobuf:protobuf-java:3.1.0'
     } else {

--- a/sources/Android/android-communications/gradle.properties
+++ b/sources/Android/android-communications/gradle.properties
@@ -19,5 +19,7 @@
 #systemProp.http.nonProxyHosts=*.peg, *.grp, *.local, 193.143.6*.*, 192.168.*.*
 #systemProp.https.proxyHost=caterpillar.polar.fi
 #systemProp.http.proxyPort=8080
-android.useDeprecatedNdk=true
+android.enableJetifier=true
+android.useAndroidX=true
+#android.useDeprecatedNdk=true
 org.gradle.daemon=true

--- a/sources/Android/android-communications/sdk/build.gradle
+++ b/sources/Android/android-communications/sdk/build.gradle
@@ -39,8 +39,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.1"
+        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.18.1"
     }
 }
 
@@ -83,5 +83,5 @@ artifactory {
 }
 
 task wrapper(type: Wrapper){
-    gradleVersion = '4.7'
+    gradleVersion = '6.7.1'
 }

--- a/sources/Android/android-communications/src/androidTest/java/com/androidcommunications/polar/InstrumentedTests.kt
+++ b/sources/Android/android-communications/src/androidTest/java/com/androidcommunications/polar/InstrumentedTests.kt
@@ -1,8 +1,8 @@
 package com.androidcommunications.polar
 
 import android.content.Context
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.androidcommunications.polar.api.ble.model.BleDeviceSession
 import com.androidcommunications.polar.enpoints.ble.bluedroid.host.BDDeviceSessionImpl
 import com.androidcommunications.polar.enpoints.ble.bluedroid.host.connection.ConnectionHandler
@@ -34,7 +34,7 @@ class InstrumentedTests {
     @Before
     fun setUp() {
         targetContext = InstrumentationRegistry.getInstrumentation().targetContext
-        connectionHandler = ConnectionHandler(targetContext, connectionInterface, scannerInterface, connectionHandlerObserver)
+        connectionHandler = ConnectionHandler(connectionInterface, scannerInterface, connectionHandlerObserver)
     }
 
     @Test

--- a/sources/Android/android-communications/src/main/AndroidManifest.xml
+++ b/sources/Android/android-communications/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
     package="com.androidcommunications.polar">
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
 </manifest>

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/BleDeviceListener.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/BleDeviceListener.java
@@ -1,10 +1,9 @@
 package com.androidcommunications.polar.api.ble;
 
 import android.bluetooth.le.ScanFilter;
-import android.support.annotation.IntDef;
-import android.support.annotation.IntRange;
-import android.support.annotation.Nullable;
-import android.util.Pair;
+import androidx.annotation.IntDef;
+import androidx.annotation.IntRange;
+import androidx.annotation.Nullable;
 
 import com.androidcommunications.polar.api.ble.model.BleDeviceSession;
 import com.androidcommunications.polar.api.ble.model.advertisement.BleAdvertisementContent;
@@ -17,7 +16,6 @@ import java.util.List;
 import java.util.Set;
 
 import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.core.Observable;
 
 public abstract class BleDeviceListener {
 

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/BleGattFactory.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/BleGattFactory.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.androidcommunications.polar.api.ble.BleLogger;
 import com.androidcommunications.polar.api.ble.model.gatt.client.BleBattClient;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleBattClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleBattClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.androidcommunications.polar.api.ble.exceptions.BleDisconnected;
 import com.androidcommunications.polar.api.ble.model.gatt.BleGattBase;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleDisClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleDisClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Pair;
 
 import com.androidcommunications.polar.api.ble.exceptions.BleAttributeError;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleGapClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleGapClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.androidcommunications.polar.api.ble.exceptions.BleDisconnected;
 import com.androidcommunications.polar.api.ble.model.gatt.BleGattBase;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleH7SettingsClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleH7SettingsClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.androidcommunications.polar.api.ble.exceptions.BleCharacteristicNotFound;
 import com.androidcommunications.polar.api.ble.exceptions.BleDisconnected;
@@ -14,7 +14,6 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.core.SingleEmitter;
 import io.reactivex.rxjava3.core.SingleOnSubscribe;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleHrClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleHrClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.androidcommunications.polar.api.ble.model.gatt.BleGattBase;
 import com.androidcommunications.polar.api.ble.model.gatt.BleGattTxInterface;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BlePMDClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BlePMDClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Pair;
 
 import com.androidcommunications.polar.api.ble.BleLogger;
@@ -32,7 +32,6 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableEmitter;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.core.SingleEmitter;
 import io.reactivex.rxjava3.core.SingleOnSubscribe;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.schedulers.Schedulers;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BlePfcClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BlePfcClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Pair;
 
 import com.androidcommunications.polar.api.ble.exceptions.BleAttributeError;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BlePsdClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BlePsdClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Pair;
 
 import com.androidcommunications.polar.api.ble.exceptions.BleAttributeError;
@@ -26,7 +26,6 @@ import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableEmitter;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.core.SingleEmitter;
 import io.reactivex.rxjava3.core.SingleOnSubscribe;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleRscClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/BleRscClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.androidcommunications.polar.api.ble.BleLogger;
 import com.androidcommunications.polar.api.ble.model.gatt.BleGattBase;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/psftp/BlePsFtpClient.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/gatt/client/psftp/BlePsFtpClient.java
@@ -1,6 +1,6 @@
 package com.androidcommunications.polar.api.ble.model.gatt.client.psftp;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Pair;
 
 import com.androidcommunications.polar.api.ble.BleLogger;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/polar/BlePolarDeviceIdUtility.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/polar/BlePolarDeviceIdUtility.java
@@ -2,6 +2,7 @@ package com.androidcommunications.polar.api.ble.model.polar;
 
 public class BlePolarDeviceIdUtility {
     public static boolean isValidDeviceId(final String deviceId){
+        if (deviceId == null) return false;
         if (deviceId.length() == 8) {
             return checkSumForDeviceId(Long.parseLong(deviceId, 16), 8) == (Long.parseLong(deviceId, 16) & 0x000000000000000FL);
         }

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/enpoints/ble/bluedroid/host/AttributeOperation.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/enpoints/ble/bluedroid/host/AttributeOperation.java
@@ -1,7 +1,7 @@
 package com.androidcommunications.polar.enpoints.ble.bluedroid.host;
 
 import android.bluetooth.BluetoothGattCharacteristic;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public class AttributeOperation implements Comparable<AttributeOperation>{
 

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/enpoints/ble/bluedroid/host/BDDeviceListenerImpl.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/enpoints/ble/bluedroid/host/BDDeviceListenerImpl.java
@@ -8,7 +8,7 @@ import android.bluetooth.BluetoothProfile;
 import android.bluetooth.le.ScanFilter;
 import android.content.Context;
 import android.os.Build;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.androidcommunications.polar.api.ble.BleDeviceListener;
 import com.androidcommunications.polar.api.ble.BleLogger;

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/enpoints/ble/bluedroid/host/BDDeviceSessionImpl.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/enpoints/ble/bluedroid/host/BDDeviceSessionImpl.java
@@ -7,7 +7,7 @@ import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.content.Context;
 import android.os.Handler;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.VisibleForTesting;
 
 import com.androidcommunications.polar.BuildConfig;
 import com.androidcommunications.polar.api.ble.BleLogger;

--- a/sources/Android/android-communications/src/main/java/polar/com/sdk/api/PolarBleApi.java
+++ b/sources/Android/android-communications/src/main/java/polar/com/sdk/api/PolarBleApi.java
@@ -1,9 +1,9 @@
 // Copyright © 2019 Polar Electro Oy. All rights reserved.
 package polar.com.sdk.api;
 
-import android.support.annotation.IntRange;
-import android.support.annotation.Nullable;
-import android.support.annotation.Size;
+import androidx.annotation.IntRange;
+import androidx.annotation.Nullable;
+import androidx.annotation.Size;
 import android.util.Pair;
 
 import java.util.Calendar;

--- a/sources/Android/android-communications/src/main/java/polar/com/sdk/api/PolarBleApiCallback.java
+++ b/sources/Android/android-communications/src/main/java/polar/com/sdk/api/PolarBleApiCallback.java
@@ -1,7 +1,7 @@
 // Copyright © 2019 Polar Electro Oy. All rights reserved.
 package polar.com.sdk.api;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.UUID;
 

--- a/sources/Android/android-communications/src/main/java/polar/com/sdk/api/PolarBleApiCallbackProvider.java
+++ b/sources/Android/android-communications/src/main/java/polar/com/sdk/api/PolarBleApiCallbackProvider.java
@@ -1,6 +1,6 @@
 // Copyright © 2019 Polar Electro Oy. All rights reserved.
 package polar.com.sdk.api;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.UUID;
 

--- a/sources/Android/android-communications/src/main/java/polar/com/sdk/impl/BDBleApiImpl.java
+++ b/sources/Android/android-communications/src/main/java/polar/com/sdk/impl/BDBleApiImpl.java
@@ -6,7 +6,7 @@ import android.bluetooth.le.ScanFilter;
 import android.content.Context;
 import android.os.Build;
 import android.os.ParcelUuid;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Pair;
 
 import com.androidcommunications.polar.api.ble.BleDeviceListener;


### PR DESCRIPTION
This pull request does the following:

1) Update 3rd party dependencies to more recent versions
2) Switch from the unmaintained Android Support library to AndroidX
3) Remove some unnecessary permissions from AndroidManifest.xml
4) Remove unused imports
5) Handle null inputs to isValidDeviceId
6) Enable warning message display during the build phase
7) Use compileOnly instead of implementation for polar-protobuf-release.aar (fixes builds using newer version of gradle)

I embarked on this cleanup because I was trying to use the BLE SDK with a newer Android app and was facing issues with AndroidX compatibility libraries.