### PR TITLE
Trivial changes to resolve broken instrumented tests

### DIFF
--- a/sources/Android/android-communications/build.gradle
+++ b/sources/Android/android-communications/build.gradle
@@ -165,6 +165,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.mockito:mockito-core:3.2.4"
     testImplementation "io.mockk:mockk:1.9.3"
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/sources/Android/android-communications/src/androidTest/java/com/androidcommunications/polar/InstrumentedTests.kt
+++ b/sources/Android/android-communications/src/androidTest/java/com/androidcommunications/polar/InstrumentedTests.kt
@@ -1,8 +1,8 @@
 package com.androidcommunications.polar
 
 import android.content.Context
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.androidcommunications.polar.api.ble.model.BleDeviceSession
 import com.androidcommunications.polar.enpoints.ble.bluedroid.host.BDDeviceSessionImpl
 import com.androidcommunications.polar.enpoints.ble.bluedroid.host.connection.ConnectionHandler
@@ -34,7 +34,7 @@ class InstrumentedTests {
     @Before
     fun setUp() {
         targetContext = InstrumentationRegistry.getInstrumentation().targetContext
-        connectionHandler = ConnectionHandler(targetContext, connectionInterface, scannerInterface, connectionHandlerObserver)
+        connectionHandler = ConnectionHandler(connectionInterface, scannerInterface, connectionHandlerObserver)
     }
 
     @Test

--- a/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/polar/BlePolarDeviceIdUtility.java
+++ b/sources/Android/android-communications/src/main/java/com/androidcommunications/polar/api/ble/model/polar/BlePolarDeviceIdUtility.java
@@ -2,6 +2,7 @@ package com.androidcommunications.polar.api.ble.model.polar;
 
 public class BlePolarDeviceIdUtility {
     public static boolean isValidDeviceId(final String deviceId){
+        if (deviceId == null) return false;
         if (deviceId.length() == 8) {
             return checkSumForDeviceId(Long.parseLong(deviceId, 16), 8) == (Long.parseLong(deviceId, 16) & 0x000000000000000FL);
         }


### PR DESCRIPTION
It appears that the ConnectionHandler interface changed some time ago and the instrumented tests have not been run recently.  There are also some deprecated classes in use.  Add a dependency on ```androidx.test.ext:junit```, update the imports, and fix the ```setUp()``` method's instantiation of ```ConnectionHandler```.  Also handle ```null``` strings in ```isValidDeviceId```.