### PR TITLE
Issue 293: Added support for CBCentralManager restore

### DIFF
--- a/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/impl/PolarBleApiImpl.swift
+++ b/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/impl/PolarBleApiImpl.swift
@@ -28,6 +28,7 @@ import UIKit
     }
     weak var cccWriteObserver: PolarBleApiCCCWriteObserver?
     weak var observer: PolarBleApiObserver?
+    
     var isBlePowered: Bool {
         get {
             return listener.blePowered()
@@ -360,8 +361,8 @@ extension PolarBleApiImpl: PolarBleApi {
 #endif
                 self.listener.openSessionDirect(session)
             })
-                .asSingle()
-                .asCompletable()
+            .asSingle()
+            .asCompletable()
                 }
     
     func connectToDevice(_ identifier: String) throws {

--- a/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/BleDeviceSession.swift
+++ b/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/BleDeviceSession.swift
@@ -7,7 +7,7 @@ public protocol BleCCCWriteProtocol: AnyObject {
     func cccWrite(_ address: UUID, characteristic: CBUUID)
 }
 
-@objc open class    BleDeviceSession: NSObject {
+@objc open class BleDeviceSession: NSObject {
     
     public enum DeviceSessionState{
         case
@@ -24,16 +24,16 @@ public protocol BleCCCWriteProtocol: AnyObject {
         
         public func description() -> String {
             switch self {
-                case .sessionClosed:
-                    return "sessionClosed"
-                case .sessionOpening:
-                    return "sessionOpening"
-                case .sessionOpenPark:
-                    return "sessionOpenPark"
-                case .sessionOpen:
-                    return "sessionOpen"
-                case .sessionClosing:
-                    return "sessionClosing"
+            case .sessionClosed:
+                return "sessionClosed"
+            case .sessionOpening:
+                return "sessionOpening"
+            case .sessionOpenPark:
+                return "sessionOpenPark"
+            case .sessionOpen:
+                return "sessionOpen"
+            case .sessionClosing:
+                return "sessionClosing"
             }
         }
     }
@@ -46,7 +46,7 @@ public protocol BleCCCWriteProtocol: AnyObject {
     }
     
     // apis to access
-    public let address:UUID 
+    public let address:UUID
     public let advertisementContent = BleAdvertisementContent()
     public var state = DeviceSessionState.sessionClosed
     public var previousState = DeviceSessionState.sessionClosed

--- a/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/BleGattClientBase.swift
+++ b/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/BleGattClientBase.swift
@@ -218,7 +218,7 @@ public class BleGattClientBase: Hashable {
         return Completable.empty()
     }
     
-    public func setServiceDiscovered(_ value: Bool, serviceUuid: CBUUID){
+    public func setServiceDiscovered(_ value: Bool) {
         serviceDiscovered.set(value)
     }
     

--- a/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/client/BlePmdClient.swift
+++ b/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/client/BlePmdClient.swift
@@ -360,15 +360,15 @@ public class BlePmdClient: BleGattClientBase {
     let pmdCpInputQueue = AtomicList<Data>()
     var features: Data?
     
-    var observersAcc = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(x: Int32,y: Int32,z: Int32)])>>()
-    var observersGyro = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(x: Float,y: Float,z: Float)])>>()
-    var observersMagnetometer = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(x: Float,y: Float,z: Float)])>>()
-    var observersEcg = AtomicList<RxObserver<(timeStamp: UInt64,samples: [Int32])>>()
-    var observersPpg = AtomicList<RxObserver<(timeStamp: UInt64, channels: UInt8, samples: [[Int32]])>>()
-    var observersPpi = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(hr: Int, ppInMs: UInt16, ppErrorEstimate: UInt16, blockerBit: Int, skinContactStatus: Int, skinContactSupported: Int)])>>()
-    var observersBioz = AtomicList<RxObserver<(timeStamp: UInt64,samples: [Int32])>>()
-    var observersFeature = AtomicList<RxObserverSingle<Pmd.PmdFeature>>()
-    var storedSettings  = AtomicType<[Pmd.PmdMeasurementType : Pmd.PmdSetting]>(initialValue: [Pmd.PmdMeasurementType : Pmd.PmdSetting]())
+    private var observersAcc = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(x: Int32,y: Int32,z: Int32)])>>()
+    private var observersGyro = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(x: Float,y: Float,z: Float)])>>()
+    private var observersMagnetometer = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(x: Float,y: Float,z: Float)])>>()
+    private var observersEcg = AtomicList<RxObserver<(timeStamp: UInt64,samples: [Int32])>>()
+    private var observersPpg = AtomicList<RxObserver<(timeStamp: UInt64, channels: UInt8, samples: [[Int32]])>>()
+    private var observersPpi = AtomicList<RxObserver<(timeStamp: UInt64,samples: [(hr: Int, ppInMs: UInt16, ppErrorEstimate: UInt16, blockerBit: Int, skinContactStatus: Int, skinContactSupported: Int)])>>()
+    private var observersBioz = AtomicList<RxObserver<(timeStamp: UInt64,samples: [Int32])>>()
+    private var observersFeature = AtomicList<RxObserverSingle<Pmd.PmdFeature>>()
+    private var storedSettings  = AtomicType<[Pmd.PmdMeasurementType : Pmd.PmdSetting]>(initialValue: [Pmd.PmdMeasurementType : Pmd.PmdSetting]())
     
     public init(gattServiceTransmitter: BleAttributeTransportProtocol){
         super.init(serviceUuid: BlePmdClient.PMD_SERVICE, gattServiceTransmitter: gattServiceTransmitter)
@@ -624,7 +624,7 @@ public class BlePmdClient: BleGattClientBase {
                 if cpResponse.errorCode == .success {
                     observer(.completed)
                 } else {
-                     observer(.error(Pmd.BlePmdError.controlPointRequestFailed(errorCode: cpResponse.errorCode.rawValue, description: cpResponse.errorCode.description)))
+                    observer(.error(Pmd.BlePmdError.controlPointRequestFailed(errorCode: cpResponse.errorCode.rawValue, description: cpResponse.errorCode.description)))
                 }
             } catch let err {
                 observer(.error(err))
@@ -634,9 +634,9 @@ public class BlePmdClient: BleGattClientBase {
     }
     
     public func readFeature(_ checkConnection: Bool) -> Single<Pmd.PmdFeature> {
-        var object: RxObserverSingle<Pmd.PmdFeature>!
         return Single.create { observer in
-            object = RxObserverSingle<Pmd.PmdFeature>(obs: observer)
+            let object = RxObserverSingle<Pmd.PmdFeature>(obs: observer)
+            
             if let f = self.features {
                 // available
                 observer(.success(Pmd.PmdFeature(f)))
@@ -648,9 +648,11 @@ public class BlePmdClient: BleGattClientBase {
                 }
             }
             return Disposables.create {
-                self.observersFeature.remove({ (item) -> Bool in
-                    return item === object
-                })
+                self.observersFeature.remove(
+                    { (item) -> Bool in
+                        return item === object
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
See the details of the feature in official apple documentation: [Bluetooth State Preservation and Restoration](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW10:~:text=and%20pending%20connections.-,State%20Preservation%20and%20Restoration,-Because%20state%20preservation)

What have been changed:
The restore forces app to be launched from terminated state, IF any BLE connections were active AND app was terminated by operating system. 

Most of the changes are done for peripheral delegates. In case of the restore, the peripheral already contains the knowledge of services, service characteristics and characteristics states. What was needed to implement, is that Polar BLE SDK state is restored back to state it was at the moment termination.