### PR TITLE
fix: make PolarDiskSpaceData properties public

### DIFF
--- a/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/api/model/PolarDiskSpaceData.swift
+++ b/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/api/model/PolarDiskSpaceData.swift
@@ -1,8 +1,8 @@
 //  Copyright © 2023 Polar. All rights reserved.
 
 public struct PolarDiskSpaceData {
-    let totalSpace: UInt64
-    let freeSpace: UInt64
+    public let totalSpace: UInt64
+    public let freeSpace: UInt64
     
     static func fromProto(proto: Protocol_PbPFtpDiskSpaceResult) -> PolarDiskSpaceData {
         return PolarDiskSpaceData(


### PR DESCRIPTION
These properties are not accessible due to implicit internal access level