### PR TITLE
fix build issue on Mac Catalyst

### DIFF
--- a/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/advertisement/BleRssiFilter.swift
+++ b/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/advertisement/BleRssiFilter.swift
@@ -17,7 +17,7 @@ public class BleRssiFilter{
                 sortedRssis.addObjects(from: rssiValues as [AnyObject])
                 let highestToLowest = NSSortDescriptor(key: "self", ascending: false)
                 sortedRssis.sort(using: [highestToLowest])
-                self.medianRssi = (sortedRssis.object(at: 3) as AnyObject).int32Value
+                self.medianRssi = (sortedRssis.object(at: 3) as! NSNumber).int32Value
                 self.rssiValues.removeObject(at: 0)
             } else {
                 self.medianRssi = rssi


### PR DESCRIPTION
When compiling the iOS SDK as part of a Mac Catalyst app, the selector `int32Value` is ambiguous, because it's defined both by [`NSNumber`](https://developer.apple.com/documentation/foundation/nsnumber) as well as [`NSAppleEventDescriptor`](https://developer.apple.com/documentation/foundation/nsappleeventdescriptor) (which isn't available on iOS, hence why everything works fine when compiling for that).

This PR fixes this issue, thereby adding the ability for Mac Catalyst applications to use the SDK and connect to polar devices.

(We know that the `NSNumber` cast is fine, bc we only ever add `NSNumber` instances to the array...)