### PR TITLE
Use concatMap when writing files to device to make sure that they are written sequentially #520

### DIFF
--- a/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/impl/PolarBleApiImpl.swift
+++ b/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/impl/PolarBleApiImpl.swift
@@ -2315,7 +2315,7 @@ extension PolarBleApiImpl: PolarBleApi  {
                                         }
 
                                         return Observable.from(sortedFirmwarePackage)
-                                            .flatMap { fileEntry -> Observable<FirmwareUpdateStatus> in
+                                            .concatMap { fileEntry -> Observable<FirmwareUpdateStatus> in
                                                 let fileName = fileEntry.key
                                                 let firmwareBytes = fileEntry.value
                                                 let filePath = "/\(fileName)"


### PR DESCRIPTION
Fixes #520 