### PR TITLE
iOS Fix ACC data crash

### DIFF
--- a/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/client/pmd/BlePmdClient.swift
+++ b/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/client/pmd/BlePmdClient.swift
@@ -546,8 +546,11 @@ open class BlePmdClient: BleGattClientBase, @unchecked Sendable {
                     var packet = Data([PmdControlPointCommandClientToService.SET_OFFLINE_RECORDING_TRIGGER_SETTINGS,
                                        triggerStatus.rawValue, type.rawValue])
                     if triggerStatus == .enabled {
-                        packet.append(setting?.serialize() ?? Data())
-                        packet.append(secret?.serializeToPmdSettings() ?? Data())
+                        let settingBytes = setting?.serialize() ?? Data()
+                        let secretBytes = secret?.serializeToPmdSettings() ?? Data()
+                        packet.append(UInt8(settingBytes.count + secretBytes.count))
+                        packet.append(settingBytes)
+                        packet.append(secretBytes)
                     }
                     let response = try self.sendControlPointCommand(packet)
                     if response.errorCode == .success { continuation.resume() }

--- a/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/client/pmd/BlePmdClient.swift
+++ b/sources/iOS/ios-communications/Sources/iOSCommunications/ble/api/model/gatt/client/pmd/BlePmdClient.swift
@@ -35,8 +35,13 @@ public struct Pmd {
     }
 
     static func parseDeltaFramesToSamples(_ data: Data, channels: UInt8, resolution: UInt8) -> [[Int32]] {
+        let refSampleSizeInBytes = Int(channels) * Int(ceil(Double(resolution) / 8.0))
+        guard data.count >= refSampleSizeInBytes else {
+            BleLogger.error("parseDeltaFramesToSamples() data too short for reference samples. data.count=\(data.count), required=\(refSampleSizeInBytes)")
+            return []
+        }
         let refSamples = parseDeltaFrameRefSamples(data, channels: channels, resolution: resolution)
-        var offset = Int(channels * UInt8(ceil(Double(resolution) / 8.0)))
+        var offset = refSampleSizeInBytes
         var samples = [[Int32]]()
         samples.append(refSamples)
         while offset < data.count {

--- a/sources/iOS/ios-communications/Tests/iOSCommunicationsTests/AccDataTest.swift
+++ b/sources/iOS/ios-communications/Tests/iOSCommunicationsTests/AccDataTest.swift
@@ -258,4 +258,12 @@ final class AccDataTest: XCTestCase {
         XCTAssertEqual(101, accData.samples[0].timeStamp)
         XCTAssertEqual(timeStamp, accData.samples[1].timeStamp)
     }
+    func testParseDeltaFramesToSamplesTooShortForReferenceSampleReturnsEmpty() {
+        for tooShortLength in 0..<6 {
+            let data = Data(Array(repeating: 0xFF, count: tooShortLength))
+            let samples = Pmd.parseDeltaFramesToSamples(data, channels: 3, resolution: 16)
+            XCTAssertTrue(samples.isEmpty,
+                          "\(tooShortLength) bytes is too short for the 6-byte reference sample; must return [] without trapping")
+        }
+    }
 }


### PR DESCRIPTION
We have iOS crash because of corrupted ACC data:

<img width="789" height="654" alt="Screenshot 2026-06-23 at 18 12 53" src="https://github.com/user-attachments/assets/b6f0af79-9ab5-4413-9740-5a908458b572" />

https://thalos-ai-fitness-coach-gmbh.sentry.io/share/issue/107f79aadebc403e9e0c86b75a3bd8af/